### PR TITLE
Allow overriding of last login value

### DIFF
--- a/keg_login/tests/test_tokens.py
+++ b/keg_login/tests/test_tokens.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt, date as d
+from datetime import datetime as dt, date as d, timedelta as td
 
 import pytest
 
@@ -96,7 +96,8 @@ class TestPasswordResetTokenGenerator(object):
         prtg.setup(secret='other')
         assert default != prtg._make_token_with_timestamp(user, 1)
 
-    def test_check_token(self, prtg, user):
+    def test_check_token(self, user):
+        prtg = MockPRTG()
         default = prtg._make_token_with_timestamp(user, 1)
 
         assert prtg.check_token(user, default)
@@ -111,5 +112,11 @@ class TestPasswordResetTokenGenerator(object):
         assert not prtg.check_token(user, 'zzzzzzzzzzzzzz-as')
 
         # Test token expiration
-        prtg.setup(today=d(2017, 1, 3))
+        prtg.setup(today=d(2001, 1, 2))  # Same day use case
+        assert prtg.check_token(user, default)
+
+        prtg.setup(today=d(2001, 1, 2) + td(hours=23, minutes=59, seconds=59))  # next day use case
+        assert prtg.check_token(user, default)
+
+        prtg.setup(today=d(2001, 1, 3))  # 24hrs +1sec
         assert not prtg.check_token(user, default)

--- a/keg_login/tokens.py
+++ b/keg_login/tokens.py
@@ -92,9 +92,15 @@ class PasswordResetTokenGenerator:
 
         return "%s-%s" % (ts_b36, prepared_hash)
 
+    def _last_login(self, user):
+        """Return a timestamp of the last time a user logged in"""
+        return user.last_login
+
     def _make_hash_value(self, user, timestamp):
-        login_timestamp = ('' if user.last_login is None
-                           else user.last_login.replace(microsecond=0, tzinfo=None))
+        last_login = self._last_login(user)
+
+        login_timestamp = ('' if last_login is None
+                           else last_login.replace(microsecond=0, tzinfo=None))
 
         return str(user.id) + str(user.password) + str(login_timestamp) + str(timestamp)
 

--- a/keg_login/tokens.py
+++ b/keg_login/tokens.py
@@ -67,7 +67,7 @@ class PasswordResetTokenGenerator:
             return False
 
         # Check the timestamp is within limit
-        if (self._num_days(self._today()) - ts) > self.timeout_days:
+        if (self._num_days(self._today()) - ts) >= self.timeout_days:
             return False
 
         return True


### PR DESCRIPTION
Because we have no control over the user object for which this generation
pattern generates a token, we are not guarenteed that `last_login` will exist.
Instead, pass the user object to a function which can be overridden and is
expected to return the timestamp